### PR TITLE
Now reads api keys from OS/container environment variables

### DIFF
--- a/openmesh/chain.py
+++ b/openmesh/chain.py
@@ -14,6 +14,9 @@ class Chain:
 
     def load_node_conf(self):
         secrets = get_secrets()
+        # maybe split this across multiple lines so we can easily parse it
+        # from what i can gather it compares the secrets (really environment variables), with the name of the current chain if they match they are assigned to each other or something
+        # [ 'ETH_WSS_URL' ], 'eth' if match then same
         return {k.split('_', maxsplit=1)[1].lower(): v for k, v in secrets.items() if k.startswith(self.name.upper())}
 
 

--- a/openmesh/helpers/read_config.py
+++ b/openmesh/helpers/read_config.py
@@ -1,5 +1,7 @@
 from configparser import ConfigParser
 import json
+import sys
+import os
 from dotenv import dotenv_values
 
 config_path = "config.ini"
@@ -15,8 +17,10 @@ def get_kafka_config():
     }
 
 
+# TODO XXX: this is misleading AF delete or explain
 def get_ethereum_provider():
-    secrets = dotenv_values(env_path)
+    secrets = dotenv_values(env_path) | os.environ
+
     return {
         "eth_node_ws_url": secrets["ETHEREUM_NODE_WS_URL"],
         "eth_node_http_url": secrets["ETHEREUM_NODE_HTTP_URL"],
@@ -25,7 +29,9 @@ def get_ethereum_provider():
 
 
 def get_secrets():
-    return dotenv_values(env_path)
+    # NOTE(Tomas): Adding os.environ here so we can set it from helm and avoid headaches
+    return dotenv_values(env_path) | os.environ
+
 
 
 def get_redis_config():


### PR DESCRIPTION
## Overview
### What does this PR do?
Now get_secrets() will also include OS environment variables. This lets us add api keys to the collector from a helm install. Plus, it makes adding new configurations simpler as we don't have to change a configuration file.

### What issues does this PR fix or reference (if any)?
None i dont think

### Checklist
- [X] - Code has been tested and works locally.
- [No] - Code quality has been checked (using a tool like flake8) and inspections pass
- [X] - Relevant documentation has been updated (if needed)